### PR TITLE
Update .gitignore for backend env file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,4 +23,4 @@ dist-ssr
 *.sln
 *.sw?
 
-.env
+.backend/env


### PR DESCRIPTION
Replaced .env with .backend/env in .gitignore to exclude environment files specific to the backend directory.